### PR TITLE
Register github:ingydotnet/foo-bar-bash=0.1.0

### DIFF
--- a/index.ini
+++ b/index.ini
@@ -1,6 +1,6 @@
 [bpan]
-version = 0.0.0
-updated = 1970-01-01T00:00:00
+version = 0.1.96
+updated = 2022-12-11T23:46:43
 
 [default]
 host = github
@@ -32,3 +32,13 @@ spdx = \
  GPL-3.0-or-later \
  MIT \
  MPL-2.0 \
+
+[package "github:ingydotnet/foo-bar-bash"]
+title = short description of 'foo-bar-bash'
+version = 0.1.0
+license = MIT
+tag = bash bpan
+author = https://github.com/ingydotnet
+pdate = 2022-12-11T23:46:43
+commit = 9ee50f6c624c4535445263d925885272dd0e9354
+sha512 = 01a74c9b7b5da56dfc7b70088b14b168926e63ed2b5b814751e81cb294c07683737e71f3f65939561d2e9edad4455cd41bae4cb294384d438019f5718e170d4c


### PR DESCRIPTION
Please add this new package to the [BPAN Index](https://github.com/bpan-org/bpan-index-test-gha/blob/main/index.ini):

> https://github.com/ingydotnet/foo-bar-bash/tree/0.1.0

    package: github:ingydotnet/foo-bar-bash
    title:   short description of 'foo-bar-bash'
    version: 0.1.0
    license: MIT
    author:  https://github.com/ingydotnet