### PR TITLE
Register github:ingydotnet/foo-bar-bash=0.1.0

### DIFF
--- a/index.ini
+++ b/index.ini
@@ -1,6 +1,6 @@
 [bpan]
-version = 0.0.0
-updated = 1970-01-01T00:00:00
+version = 0.1.96
+updated = 2022-12-11T23:51:08
 
 [default]
 host = github
@@ -32,3 +32,13 @@ spdx = \
  GPL-3.0-or-later \
  MIT \
  MPL-2.0 \
+
+[package "github:ingydotnet/foo-bar-bash"]
+title = short description of 'foo-bar-bash'
+version = 0.1.0
+license = MIT
+tag = bash bpan
+author = https://github.com/___
+pdate = 2022-12-11T23:51:08
+commit = e3082cb57586ecf6945120aa5fcca0424b9219bd
+sha512 = a42f6b82931123b834faf29bc17cd2ba966e05ccef4aec8a6be3e1182a6b1d06cb506e33130d0e30ae9e4553cc39c2e19af5048a7529475b2ea6452b03dc25ff


### PR DESCRIPTION
Please add this new package to the [BPAN Index](https://github.com/bpan-org/bpan-index-test-gha/blob/main/index.ini):

> https://github.com/ingydotnet/foo-bar-bash/tree/0.1.0

    package: github:ingydotnet/foo-bar-bash
    title:   short description of 'foo-bar-bash'
    version: 0.1.0
    license: MIT
    author:  https://github.com/ingydotnet