### PR TITLE
Register github:ingydotnet/foo-bar-bash=0.1.0

### DIFF
--- a/index.ini
+++ b/index.ini
@@ -1,6 +1,6 @@
 [bpan]
-version = 0.0.0
-updated = 1970-01-01T00:00:00
+version = 0.1.96
+updated = 2022-12-12T01:21:48
 
 [default]
 host = github
@@ -32,3 +32,13 @@ spdx = \
  GPL-3.0-or-later \
  MIT \
  MPL-2.0 \
+
+[package "github:ingydotnet/foo-bar-bash"]
+title = short description of 'foo-bar-bash'
+version = 0.1.0
+license = MIT
+tag = bash bpan
+author = https://github.com/ingydotnet
+pdate = 2022-12-12T01:21:48
+commit = 3f6d3a3b231afd15800792470701cc32ebb05d17
+sha512 = b5c2d0981dddeef7e1a62726bf19d8aa21ea7898f34dc4554ae077a8a0c747f4008708879e800d928dcc353f5d6ffb442008bf9d77be7a95f27729f860967b4a


### PR DESCRIPTION
Please add this new package to the [BPAN Index](https://github.com/bpan-org/bpan-index-test-gha/blob/main/index.ini):

> https://github.com/ingydotnet/foo-bar-bash/tree/0.1.0

    package: github:ingydotnet/foo-bar-bash
    title:   short description of 'foo-bar-bash'
    version: 0.1.0
    license: MIT
    author:  https://github.com/ingydotnet