### PR TITLE
Register github:bpan-org/bashplus=0.1.60

### DIFF
--- a/index.ini
+++ b/index.ini
@@ -1,6 +1,6 @@
 [bpan]
-version = 0.0.0
-updated = 1970-01-01T00:00:00Z
+version = 0.1.100
+updated = 2022-12-15T12:47:05Z
 
 [default]
 host = github
@@ -26,3 +26,14 @@ CDDL-1.0 \
 GPL-3.0-or-later \
 MIT \
 MPL-2.0 \
+
+[package "github:bpan-org/bashplus"]
+title = A Collection of Useful Bash Functions
+version = 0.1.60
+license = MIT
+tag = bash plus
+source = https://github.com/bpan-org/help/tree/0.1.60
+author = https://github.com/ingydotnet
+update = 2022-12-15T12:47:05Z
+commit = 15c74a5c13aa60ef62c5cf4a91be97ecfd21f8c8
+sha512 = 3d87c3898d62317bed7973e94727c999971f169f0ed7250b0d99ca1b9620443934736056b320ac0ff0e17189d12d05e8347b70dc1551dd246ab451a84b8185fe


### PR DESCRIPTION
Please add this new package to the [BPAN Index](https://github.com/bpan-org/bpan-index-test-gha/blob/main/index.ini):

> https://github.com/bpan-org/bashplus/tree/0.1.60

    package: github:bpan-org/bashplus
    title:   A Collection of Useful Bash Functions
    version: 0.1.60
    license: MIT
    author:  https://github.com/ingydotnet