### PR TITLE
Register github:bpan-org/bashplus=0.1.63

### DIFF
--- a/index.ini
+++ b/index.ini
@@ -1,6 +1,6 @@
 [bpan]
-version = 0.0.0
-updated = 1970-01-01T00:00:00Z
+version = 0.1.104
+updated = 2022-12-19T00:08:44Z
 
 [default]
 host = github
@@ -26,3 +26,16 @@ CDDL-1.0 \
 GPL-3.0-or-later \
 MIT \
 MPL-2.0 \
+
+[package "github:bpan-org/bashplus"]
+title = A Collection of Useful Bash Functions
+version = 0.1.63
+license = MIT
+summary = 
+type = bash-lib
+tag = 
+source = https://github.com/bpan-org/bashplus/tree/0.1.63
+author = https://github.com/ingydotnet
+update = 2022-12-19T00:08:44Z
+commit = b68c22072c441a85db0dfa24c322b0c403df29e8
+sha512 = 2dad80aedc07c4a3e7b1b54dda68d77737c364dd45aed49ccb86d08c73b78c3ea103c056cf4e0e8b34536bb5553cc690aa0261f76ef6683b5fc840fe36d8328c


### PR DESCRIPTION
Please add this new package to the [BPAN Index](https://github.com/bpan-org/bpan-index-test-gha/blob/main/index.ini):

> https://github.com/bpan-org/bashplus/tree/0.1.63

    package: github:bpan-org/bashplus
    title:   A Collection of Useful Bash Functions
    version: 0.1.63
    type:    bash-lib
    license: MIT
    author:  https://github.com/ingydotnet